### PR TITLE
added stabalizer holes for 6.25u spcaebar

### DIFF
--- a/kle/lib/KeyMatrix.tsx
+++ b/kle/lib/KeyMatrix.tsx
@@ -62,6 +62,14 @@ export const KeyMatrix = ({
             {colToMicroPin?.[key.col] !== undefined && (
               <trace from={`.${key.name} .pin2`} to={colToMicroPin[key.col]} />
             )}
+                {key.name === 'K_SPACE' && (
+              <>
+        <hole pcbX={-50} pcbY={4} diameter={4} />
+        <hole pcbX={-50} pcbY={-11} diameter={3.2} />
+        <hole pcbX={50} pcbY={4} diameter={4} />
+        <hole pcbX={50} pcbY={-11} diameter={3.2} />
+              </>
+            )}
           </group>
         )
       })}


### PR DESCRIPTION
you won't believe how hard is it to get the right dimensions for the stabilizers, I was searching everywhere AI datasheets etx
in the end I got this https://www.pcbway.com/project/shareproject/Mechanical_Keyboard_60_ISO_d34238f2.html
I opened the gerber on jlcpcb viewer and had to measure it manually.
![image](https://github.com/user-attachments/assets/e7f397b4-1b15-42fa-971d-7c6d340dd941)
https://cart.jlcpcb.com/quote/gerberviewThree/?qs=c108aa1cdc63478785792eb075854ae9_1_0_1_0_0.html
resources used
![image](https://github.com/user-attachments/assets/73235bcb-c448-4b9c-bbb1-2549446f0225)
